### PR TITLE
Add Weekly Update folder and .md files

### DIFF
--- a/weekly-updates/weekly-update.02-06-2015.md
+++ b/weekly-updates/weekly-update.02-06-2015.md
@@ -1,0 +1,20 @@
+Every Friday we're going to start posting weekly updates of the activity in and around the project. I'll kick off a new issue each week and we can comment and collaboratively edit it before publication.
+
+# io.js in the week of February 6th 2015
+
+We looked back at all the contributions in January and found that this is the 3rd most active month in Node history (294 commits) and the single most active month in almost three years (308 commits in February 2012). With the contribution growth we've seen so far we expect February to be even more active.
+
+* 1.1.0 release. https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#2015-02-03-version-110-chrisdickinson
+* Simplified Stream Construction https://github.com/iojs/io.js/commit/50daee7243a3f987e1a28d93c43f913471d6885a
+* io.js support added to Travis CI http://docs.travis-ci.com/user/build-environment-updates/2015-02-03/
+* codeship supports io.js https://codeship.com/documentation/languages/nodejs/#iojs
+* Atom Editor moved to io.js. https://github.com/atom/atom/releases/tag/v0.177.0
+* nw.js (formerly node-webkit) moved to io.js https://github.com/nwjs/nw.js/issues/2742
+* New Tessel Hardware will support io.js http://blog.technical.io/post/110115579867/upcoming-hardware-from-technical-machine
+* Chris Dickinson on-boarded six new committers, bringing the total number of active committers to 23. https://github.com/iojs/io.js/issues/680#issuecomment-73089691
+* WIP: Stability and Compatibility Policy https://github.com/iojs/io.js/issues/725
+* TC Meeting Highlights
+* Website Working Group Highlights
+* First Tracing Working Group Meeting
+* We've started reaching out to companies for feedback on our roadmap. https://github.com/iojs/roadmap/issues/13 If there are any companies we missed please drop the contact information in to that GitHub Issue.
+* Next week is Node Summit w/ many io.js people speaking and in attendance. Bert Belder,  Thorsten Lorenz, will be speaking Isaac Schlueter.

--- a/weekly-updates/weekly-update.02-13-2015.md
+++ b/weekly-updates/weekly-update.02-13-2015.md
@@ -1,0 +1,89 @@
+## io.js support added by...
+* [Postmark](http://blog.postmarkapp.com/post/110829734198/its-official-were-getting-cozy-with-node-js)
+* [node-serialport](https://github.com/voodootikigod/node-serialport/issues/439)
+* [Microsoft Azure](http://azure.microsoft.com/en-us/documentation/articles/web-sites-nodejs-iojs/)
+
+## io.js breaks 10,000 stars on GitHub
+On Feb. 13, io.js reached the goal of 10,000 stars on GitHub. We couldn't have done it without the support of the amazing community behind JavaScript. Thank you alll!
+
+## io.js 1.2.0 released
+* **stream**: Simpler stream construction ([readable-stream/issues#102[(https://github.com/iojs/readable-stream/issues/102))
+* **dns**: `lookup()` now supports an `'all'` boolean option, default to `false` but when turned on will cause the method to return an array of all resolved names for an address, see, ([iojs/pull#744](https://github.com/iojs/io.js/pull/744))
+* **assert**: Remove `prototype` property comparison in `deepEqual()` ([iojs/issues#636](https://github.com/iojs/io.js/pull/636)); introduce a `deepStrictEqual()` method to mirror `deepEqual()` but performs strict equality checks on primitives ([iojs/issues#639](https://github.com/iojs/io.js/pull/639)).
+* **tracing**: Add [LTTng](http://lttng.org/) (Linux Trace Toolkit Next Generation) when compiled with the `--with-lttng option`. Trace points match those available for DTrace and ETW. ([iojs/issues#702](https://github.com/iojs/io.js/pull/702))
+* **docs**: Lots of doc updates, see individual commits; new Errors page discussing JavaScript errors, V8 specifics, and io.js specific error details.
+* **npm** upgrade to 2.5.1
+* **libuv** upgrade to 1.4.0, see libuv [ChangeLog](https://github.com/libuv/libuv/blob/v1.x/ChangeLog)
+* Add new collaborators:
+  * Aleksey Smolenchuk (@lxe)
+  * Shigeki Ohtsu (@shigeki)
+
+## Opened our doors to the international community
+View the [original article](https://medium.com/@mikeal/how-io-js-built-a-146-person-27-language-localization-effort-in-one-day-65e5b1c49a62) on Medium.
+* Added interested contributors to teams for their language.
+* Teams registered Twitter accounts for their teams and other relevant social media accounts.
+* Teams came up with their own ways of working together, and they became more of "community organizers," as opposed to just "translators"
+
+### Stats for Localizations:
+
+* 146 people signed up to help with the localizations the first day (over 160 signed up now)
+* 27 languages communities created the first day (already up to 29)
+
+### Language Communities
+
+* [`iojs-bn`](https://github.com/iojs/iojs-bn) Bengali Community
+* [`iojs-cn`](https://github.com/iojs/iojs-cn) Chinese Community
+* [`iojs-cs`](https://github.com/iojs/iojs-cs) Czech Community
+* [`iojs-da`](https://github.com/iojs/iojs-da) Danish Community
+* [`iojs-de`](https://github.com/iojs/iojs-de) German Community
+* [`iojs-el`](https://github.com/iojs/iojs-el) Greek Community
+* [`iojs-es`](https://github.com/iojs/iojs-es) Spanish Community
+* [`iojs-fa`](https://github.com/iojs/iojs-fa) Persian Community
+* [`iojs-fi`](https://github.com/iojs/iojs-fi) Finnish Community
+* [`iojs-fr`](https://github.com/iojs/iojs-fr) French Community
+* [`iojs-he`](https://github.com/iojs/iojs-he) Hebrew Community
+* [`iojs-hi`](https://github.com/iojs/iojs-hi) Hindi Community
+* [`iojs-hu`](https://github.com/iojs/iojs-hu) Hungarian Community
+* [`iojs-id`](https://github.com/iojs/iojs-id) Indonesian Community
+* [`iojs-it`](https://github.com/iojs/iojs-it) Italian Community
+* [`iojs-ja`](https://github.com/iojs/iojs-ja) Japanese Community
+* [`iojs-ka`](https://github.com/iojs/iojs-ka) Georgian Community
+* [`iojs-kr`](https://github.com/iojs/iojs-kr) Korean Community
+* [`iojs-mk`](https://github.com/iojs/iojs-mk) Macedonian Community
+* [`iojs-nl`](https://github.com/iojs/iojs-nl) Dutch Community
+* [`iojs-no`](https://github.com/iojs/iojs-no) Norwegian Community
+* [`iojs-pl`](https://github.com/iojs/iojs-pl) Polish Community
+* [`iojs-pt`](https://github.com/iojs/iojs-pt) Portuguese Community
+* [`iojs-ro`](https://github.com/iojs/iojs-ro) Romanian Community
+* [`iojs-ru`](https://github.com/iojs/iojs-ru) Russian Community
+* [`iojs-sv`](https://github.com/iojs/iojs-sv) Swedish Community
+* [`iojs-tr`](https://github.com/iojs/iojs-tr) Turkish Community
+* [`iojs-tw`](https://github.com/iojs/iojs-tw) Taiwan Community
+* [`iojs-uk`](https://github.com/iojs/iojs-uk) Ukranian Community
+
+## io.js and Node.js
+View the [original article](https://medium.com/@iojs/io-js-and-a-node-js-foundation-4e14699fb7be) on Medium.
+* Scott Hammond, CEO of Joyent, expressed his desire to bring io.js back to the node.js.
+
+#### In only a few months io.js...
+* Has grown to 23 active core team members
+* Has several working groups
+* Has 29 language localization teams,
+* Has drawn more contributors to the project than we’ve ever had in the history of node.js, and
+* Has been able to release quality software at a good pace with the support of an exceptional community.
+
+> We are eager to put this all behind us but we can’t sacrifice the progress we’ve made or the principles and open governance that got us here.
+
+### The Future
+* Talks with the node.js foundation are ongoing.
+* Once the foundation has a technical governance model you will see an issue on io.js’ GitHub about whether io.js should join.
+
+  * This will be discussed and voted on openly in a public TC meeting following the governance rules we’ve already built.
+
+> For the community, nothing has changed.
+
+### What to do right now
+* Continue to send your pull requests to io.js
+* Join one of the 27 [language localization teams](https://github.com/iojs/website/issues/125)
+* Contribute to io.js’ working groups ([streams](https://github.com/iojs/readable-stream), [website](https://github.com/iojs/website), [evangelism](https://github.com/iojs/website/labels/evangelism), [tracing](https://github.com/iojs/tracing-wg), [build](https://github.com/iojs/build), [roadmap](https://github.com/iojs/roadmap)) and
+* Continue to adopt io.js in your applications.

--- a/weekly-updates/weekly-update.02-20-2015.md
+++ b/weekly-updates/weekly-update.02-20-2015.md
@@ -1,0 +1,28 @@
+## io.js Releases 1.3.0
+Notable changes include:
+* **url**: `url.resolve('/path/to/file', '.')` now returns `/path/to/` with the trailing slash, `url.resolve('/', '.')` returns `/` [#278](https://github.com/iojs/io.js/pull/278) (Amir Saboury)
+* **tls**: The default cipher suite used by `tls` and `https` has been changed to one that achieves Perfect Forward Secrecy with all modern browsers. Additionally, insecure RC4 ciphers have been excluded. If you absolutely require RC4, please specify your own cipher suites. [#826](https://github.com/iojs/io.js/pull/826) (Roman Reiss)
+
+## Notable Events in the Community
+* **Node Governance** - [William Bert](https://twitter.com/williamjohnbert) created http://nodegovernance.io/ to alert Scott Hammond, CEO of Joyent, of the desire of the community for the io.js open-governance model to be the base upon which the Node Foundation's Technical Committee. The response from the community was _fantastic_!
+* **Node.js and io.js Performance Improves** - Raygun.io did performance tests with both Node.js and io.js recently, and both are improving performance with each release! [Read the full article](https://raygun.io/blog/2015/02/node-js-performance-node-js-vs-io-js/).
+* **LTTng Basics** - [LTTing Basics](https://asciinema.org/a/16785) with io.js by user jgalar on asciinema
+* **io.js Roadmap Slides** - Slide deck for the current roadmap of io.js up.
+
+### io.js Support Added
+* [TravisCI](https://travis-ci.org/) added io.js.The day the last Weekly Update was posted, Hiro Asari (あさり) [tweeted](https://twitter.com/hiro_asari/status/566268486012633088) that about 10% of Node projects were running io.js.
+* @thlorenz updated [nad](https://github.com/thlorenz/nad), Node Addon Developer, to [support io.js](https://twitter.com/thlorenz/status/566328088121081856)
+* [Catberry.js](https://github.com/catberry/catberry) added support for io.js.
+* Official mongodb node module supports io.js in [v. 2.0.16 2015-02-16](https://github.com/mongodb/node-mongodb-native/blob/2.0/HISTORY.md).
+* [The Native Web](http://www.thenativeweb.io/) now has a [io.js Docker container](https://registry.hub.docker.com/u/thenativeweb/iojs/)
+* [DNSChain](https://github.com/okTurtles/dnschain) by [okTurtles](https://okturtles.com/) added support for io.js.
+* [TDPAHACLPlugin](https://github.com/neilstuartcraig/TDPAHACLPlugin) and [TDPAHAuthPlugin](https://github.com/neilstuartcraig/TDPAHAuthPlugin) for [actionHero](http://www.actionherojs.com/) now support io.js.
+* [node-sass](https://npmjs.org/package/node-sass) added support for io.js 1.2 in node-sass [v. 2.0.1](https://github.com/sass/node-sass/issues/655)
+* [total.js](https://www.totaljs.com/) added support for io.js in [v. 1.7.1](https://github.com/totaljs/framework/releases/tag/v1.7.1)
+* [Clever Cloud](https://www.clever-cloud.com/) added [support for io.js](https://www.clever-cloud.com/blog/features/2015/01/23/introducing-io.js/)
+
+## io.js Working Group Meetings
+* io.js Tracing Working Group Meeting - Feb. 19, 2015: [YouTube](https://www.youtube.com/watch?v=wvBVjg8jkv0) - [Minutes](https://docs.google.com/document/d/1_ApOMt03xHVkaGpTEPMDIrtkjXOzg3Hh4ZcyfhvMHx4/edit)
+* io.js Build Working Group Meeting - Feb. 19, 2015: [YouTube](https://www.youtube.com/watch?v=OKQi3pTF7fs) - [SoundCloud](https://soundcloud.com/iojs/iojs-build-wg-meeting-2015-02-19) - [Minutes](https://docs.google.com/document/d/1vRhsYBs4Hw6vRu55h5eWTwDzS1NctxdTvMMEnCbDs14/edit)
+* io.js Technical Committee Meeting - Feb. 18, 2015: [YouTube](https://www.youtube.com/watch?v=jeBPYLJ2_Yc) - [SoundCloud](https://soundcloud.com/iojs/iojs-tc-meeting-meeting-2015-02-18) - [Minutes](https://docs.google.com/document/d/1JnujRu6Rfnp6wvbvwCfxXnsjLySunQ_yah91pkvSFdQ/edit)
+* io.js Website Working Group Meeting - Feb. 16, 2015: [YouTube](https://www.youtube.com/watch?v=UKDKhFV61ZA) - [SoundCloud](https://soundcloud.com/iojs/iojs-website-wg-meeting-2015-02-16) - [Minutes](https://docs.google.com/document/d/1R8JmOoyr64tt-QOj27bD19ZOWg63CujW7GeaAHIIkUs/edit)


### PR DESCRIPTION
Added all previous Weekly Updates in a folder named weekly-updates.

This will allow easy access to them for reference, review, use, etc. in
the future without having to go through the issues of iojs/website AND
iojs/evangelism.

Naming convention: weekly-update.`MM`-`DD`-`YYYY`.md
