### PR TITLE
Created a proposal roadmap for the thread summary process

### DIFF
--- a/documents/core_issues/README.md
+++ b/documents/core_issues/README.md
@@ -1,0 +1,14 @@
+# Core issues summary articles
+
+The evangelism WG can summarize threads that become too long to be read and understood in a reasonable time. The format
+of such summaries is yet to be defined.
+
+## Goals
+
+* It will be easier for newcomers to join an ongoing discussion.
+* External communication regarding the uture orientations of the platform will be clearer.
+
+## Roadmap
+
+This mechanism is still being defined. A [roadmap](./roadmap.md) is available. Feel free to contribute through PR and by
+filling issues.

--- a/documents/core_issues/README.md
+++ b/documents/core_issues/README.md
@@ -6,7 +6,7 @@ of such summaries is yet to be defined.
 ## Goals
 
 * It will be easier for newcomers to join an ongoing discussion.
-* External communication regarding the uture orientations of the platform will be clearer.
+* External communication regarding the future orientations of the platform will be clearer.
 
 ## Roadmap
 

--- a/documents/core_issues/roadmap.md
+++ b/documents/core_issues/roadmap.md
@@ -1,0 +1,29 @@
+# Roadmap
+
+The Evangelism WG will hold the editorial responsibility of the summaries.
+
+## Meta
+
+- [ ] Define the scope of the mechanism. (e.g. core only/all WG)
+- [ ] Within the scope, define which threads can be eligible to be summarized. (e.g. all/technical only/threads regarding 
+important decisions only)
+- [ ] Define what will be the form of the summary articles. (e.g. blog-post/list-style/quote compilation)
+- [ ] Decide how to define what is relevant within a thread and what is not.
+- [ ] Define where will those articles be published? (e.g. Foundation website/Github/Medium)
+- [ ] Define what happens to a thread after it has been summarized or what happens to an article if the thread need to
+be summarized again later with newer content.
+- [ ] Define what will be the license and copyright status of the articles.
+
+## Process
+
+- [ ] Define the starting point of the process.
+- [ ] Define how to assign people to the witting of an article.
+- [ ] Define the validation process of an article.
+- [ ] Define the publication process of an article.
+- [ ] Define the conditions under which a revision should/can be made and the necessary process.
+
+## People
+
+- [ ] Define who will be in charge of the supervision of the process.
+- [ ] Define who is eligible to be a writer. (The team behind an article must hold sufficient technical knowledge 
+regarding the topic)


### PR DESCRIPTION
This follows discussions in #241 regarding the writing of articles summarizing of long threads within the organisation.
