### PR TITLE
Add London initiatives

### DIFF
--- a/documents/local_initiatives/current-initiatives.md
+++ b/documents/local_initiatives/current-initiatives.md
@@ -22,5 +22,6 @@ Chennai | Node.js Chennai | <https://www.meetup.com/nodejs-Chennai> | Twitter: [
 
 Location | Event | Website | Contact Point
 -------- | ----- | ------- | -------------
-London | Node Girls London | <https://nodegirls.io/london> | Twitter: [@nodegirls_ldn](https://twitter.com/nodegirls_ldn)
 London | London Node User Group (LNUG) | <https://lnug.org/> | Twitter: [@LNUGorg](https://twitter.com/LNUGorg)
+London | NodeSchool London | <https://nodeschool.io/london/> | Gitter: [NodeSchool London](https://gitter.im/nodeschool/london)
+London | Node Girls London | <https://nodegirls.io/london> | Twitter: [@nodegirls_ldn](https://twitter.com/nodegirls_ldn)

--- a/documents/local_initiatives/current-initiatives.md
+++ b/documents/local_initiatives/current-initiatives.md
@@ -15,3 +15,12 @@ St. Louis | Node.jSTL | <https://www.meetup.com/node-jSTL/> | Twitter: [@thekeit
 Location | Event | Website | Contact Point
 -------- | ----- | ------- | -------------
 Chennai | Node.js Chennai | <https://www.meetup.com/nodejs-Chennai> | Twitter: [@dfourthi](https://twitter.com/dfourthi), [@nodejs_chennai](https://twitter.com/nodejs_chennai)
+
+## United Kingdom
+
+### London
+
+Location | Event | Website | Contact Point
+-------- | ----- | ------- | -------------
+London | Node Girls London | <https://nodegirls.io/london> | Twitter: [@nodegirls_ldn](https://twitter.com/nodegirls_ldn)
+London | London Node User Group (LNUG) | <https://lnug.org/> | Twitter: [@LNUGorg](https://twitter.com/LNUGorg)


### PR DESCRIPTION
Just adding initiatives in London: [Node Girls](http://nodegirls.io/london), [NodeSchool](https://nodeschool.io/london/) and the [London Node User Group](https://lnug.org/).