### PR TITLE
Remove Gitter Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ How to get involved!
 
 There are lots of ways to contribute to [Node.js](https://github.com/nodejs). If you are interested in contribution to Node.js evangelism specifically, feel free to join in the conversations, help with [issues](https://github.com/nodejs/evangelism/issues), and share the [roadmap](https://github.com/nodejs/roadmap/). You don't have to be a member of the Working Group to pitch in!
 
-Join the conversation!
-
-[![Join the chat at https://gitter.im/nodejs/evangelism](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodejs/evangelism?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 ### Governance and Contributing
 The Node.js Evangelism WG has adopted the core governance and contributing policies of Node.js.
 


### PR DESCRIPTION
This commit removes the Gitter badge from the repo. AFAIK this Gitter channel is not active, and could be an active detractor from people interested in joining in on the WG.