### PR TITLE
Adds note about CommComm

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ You can view them at:
 [GOVERNANCE.md](./GOVERNANCE.md)  
 [CONTRIBUTING.md](./CONTRIBUTING.md)
 
+The Evangelism WG is overseen by the [Node.js Community Committee](https://github.com/nodejs/community-committee).
+
 ### Evangelism WG Members
 
 * [Mikeal Rogers](http://github.com/mikeal) - [@mikeal](http://twitter.com/mikeal)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can view them at:
 [GOVERNANCE.md](./GOVERNANCE.md)  
 [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-The Evangelism WG is overseen by the [Node.js Community Committee](https://github.com/nodejs/community-committee).
+The Evangelism WG is chartered by the [Node.js Community Committee](https://github.com/nodejs/community-committee).
 
 ### Evangelism WG Members
 


### PR DESCRIPTION
Adds a note that the Evangelism WG is under the CommComm. Likely the final step for https://github.com/nodejs/evangelism/issues/294